### PR TITLE
Don't fail on trying to stringify undefined keys, just ignore them

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,17 +38,18 @@ function stringifyObject (obj) {
             keys = Object.keys(obj);
         for (var i = 0; i < keys.length; i++) {
             var key = keys[i];
-            if (obj[key] !== undefined && obj[key] !== null) {
-                if (i !== 0) {
-                    res += ',';
-                }
-                if (/^[a-z_$][a-z0-9_$]*$/.test(key)) {
-                    res += key + ':';
-                } else {
-                    res += "'" + key.replace(/'/g, "\\'") + "':";
-                }
-                res += stringifyObject(obj[key]);
+            if (obj[key] === undefined || obj[key] === null) {
+                continue;
             }
+            if (i !== 0) {
+                res += ',';
+            }
+            if (/^[a-z_$][a-z0-9_$]*$/.test(key)) {
+                res += key + ':';
+            } else {
+                res += "'" + key.replace(/'/g, "\\'") + "':";
+            }
+            res += stringifyObject(obj[key]);
         }
         res += '}';
         return res;

--- a/index.js
+++ b/index.js
@@ -38,15 +38,17 @@ function stringifyObject (obj) {
             keys = Object.keys(obj);
         for (var i = 0; i < keys.length; i++) {
             var key = keys[i];
-            if (i !== 0) {
-                res += ',';
+            if (obj[key] !== undefined && obj[key] !== null) {
+                if (i !== 0) {
+                    res += ',';
+                }
+                if (/^[a-z_$][a-z0-9_$]*$/.test(key)) {
+                    res += key + ':';
+                } else {
+                    res += "'" + key.replace(/'/g, "\\'") + "':";
+                }
+                res += stringifyObject(obj[key]);
             }
-            if (/^[a-z_$][a-z0-9_$]*$/.test(key)) {
-                res += key + ':';
-            } else {
-                res += "'" + key.replace(/'/g, "\\'") + "':";
-            }
-            res += stringifyObject(obj[key]);
         }
         res += '}';
         return res;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "template-expression-compiler",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "license": "Apache-2.0",
   "main": "index.js",
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -28,7 +28,7 @@ var testCases = [
     tassembly: "{headers:{'content-type':rc.g.default(rm.request.headers['content-type'],'text/html')}}",
 },
 {
-    expression: {headers:{"content-type": "$$.default($.request.headers.content-type,'text/html')"}},
+    expression: {headers:{"content-type": "$$.default($.request.headers.content-type,'text/html')"}, body: undefined},
     tassembly: "{headers:{'content-type':rc.g.default(rm.request.headers['content-type'],'text/html')}}",
 },
 {


### PR DESCRIPTION
In case a key value is undefined or null we fail to stringify. Just ignore undefined and null keys.

cc @wikimedia/services 